### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ EXAMPLE
 ```hcl
 module "dcos-elbs" {
   source  = "dcos-terraform/elb-dcos/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "production"
 

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@
  *```hcl
  * module "dcos-elbs" {
  *   source  = "dcos-terraform/elb-dcos/aws"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   cluster_name = "production"
  *
@@ -41,7 +41,7 @@ provider "aws" {}
 
 module "dcos-elb-masters" {
   source  = "dcos-terraform/elb-masters/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"
@@ -59,7 +59,7 @@ module "dcos-elb-masters" {
 
 module "dcos-elb-masters-internal" {
   source  = "dcos-terraform/elb-masters-internal/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"
@@ -76,7 +76,7 @@ module "dcos-elb-masters-internal" {
 
 module "dcos-elb-public-agents" {
   source  = "dcos-terraform/elb-public-agents/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2